### PR TITLE
fix bug with p2 stages not showing thresholds on sensitivity panel

### DIFF
--- a/smx-config/MainWindow.xaml.cs
+++ b/smx-config/MainWindow.xaml.cs
@@ -462,9 +462,26 @@ namespace smx_config
             ConnectedPadList.Visibility = TwoControllersConnected ? Visibility.Visible : Visibility.Collapsed;
 
             // Only show the P1/P2 text if only one controller is connected, since it takes the place
-            // of the dropdown.
-            P1Connected.Visibility = (!TwoControllersConnected && args.controller[0].info.connected) ? Visibility.Visible : Visibility.Collapsed;
-            P2Connected.Visibility = (!TwoControllersConnected && args.controller[1].info.connected) ? Visibility.Visible : Visibility.Collapsed;
+            // of the dropdown. Make sure to set the selectedPad too in case callers use that to determine
+            // which pad is being configured.
+            if (!TwoControllersConnected && args.controller[0].info.connected)
+            {
+                P1Connected.Visibility = Visibility.Visible;
+                ActivePad.selectedPad = ActivePad.SelectedPad.P1;
+            } else
+            {
+                P1Connected.Visibility = Visibility.Collapsed;
+            }
+
+            if (!TwoControllersConnected && args.controller[1].info.connected)
+            {
+                P2Connected.Visibility = Visibility.Visible;
+                ActivePad.selectedPad = ActivePad.SelectedPad.P2;
+            }
+            else
+            {
+                P2Connected.Visibility = Visibility.Collapsed;
+            }
 
             if(!TwoControllersConnected)
                 return;


### PR DESCRIPTION
The usage of `ActivePad.selectedPad` in [ThresholdSlider](https://github.com/BenouKat/stepmaniax-sdk/blob/master/smx-config/Source/Controllers/ThresholdSlider.cs#L97) defaults to P1 if `ActivePad.selectedPad` is set to `Both`. This seems to be an error, as the UI displays `Connected: P2` if only a P2 pad is connected.

This PR fixes it so that when the UI decides to show what is connected, it also updates the `ActivePad.selectedPad` variable to indicate which Pad was detected.