### PR TITLE
improve sensor test data retrieval rate from firmware by asking more often

### DIFF
--- a/sdk/Windows/SMXDevice.cpp
+++ b/sdk/Windows/SMXDevice.cpp
@@ -476,7 +476,7 @@ void SMX::SMXDevice::UpdateSensorTestMode()
     {
         // This request should be quick.  If we haven't received a response in a long
         // time, assume the request wasn't received.
-        if(now - m_SentSensorTestModeRequestAtTicks < 2000)
+        if(now - m_SentSensorTestModeRequestAtTicks < 30)
             return;
     }
 

--- a/smx-config/App.xaml.cs
+++ b/smx-config/App.xaml.cs
@@ -11,6 +11,11 @@ namespace smx_config
         [DllImport("SMX.dll", CallingConvention = CallingConvention.Cdecl)]
         private static extern void SMX_Internal_OpenConsole();
 
+        [DllImport("kernel32.dll")]
+        public static extern bool SetStdHandle(int stdHandle, IntPtr handle);
+        [DllImport("kernel32.dll")]
+        public static extern bool AllocConsole();
+
         private System.Windows.Forms.NotifyIcon trayIcon;
         private MainWindow window;
 
@@ -24,11 +29,19 @@ namespace smx_config
             base.OnStartup(e);
 
             // If an instance is already running, foreground it and exit.
-            if(ForegroundExistingInstance())
+            if (ForegroundExistingInstance())
             {
                 Shutdown();
                 return;
             }
+
+            // Only create a console to show SMX.dll logs and other console logs if built for debug
+#if DEBUG
+            SetStdHandle(-10, IntPtr.Zero); // stdin
+            SetStdHandle(-11, IntPtr.Zero); // stdout
+            SetStdHandle(-12, IntPtr.Zero); // stderr
+            AllocConsole();
+#endif
 
             // This is used by the installer to close a running instance automatically when updating.
             ListenForShutdownRequest();


### PR DESCRIPTION
The result is that the pressure display bars now update at ~60fps rather than ~9-18fps as they did previously.

I have no idea if this has any weird side effects but after some testing on a Gen 5 SMX pad I didn't see any. Requires the DLL to be rebuilt and distributed.

Also adds some code to enable a console to see logs from the DLL functions when building for Debug target.